### PR TITLE
Make 'ast' and 'parser' modules public

### DIFF
--- a/lrpeg/src/lib.rs
+++ b/lrpeg/src/lib.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::Path;
 use unicode_xid::UnicodeXID;
 
-mod ast;
+pub mod ast;
 mod check;
-mod parser;
+pub mod parser;
 mod utils;
 
 use utils::{escape_char, escape_string, KEYWORDS};


### PR DESCRIPTION
Hi Sean,

I need to access the internal modules 'ast' and 'parser' so I've added optional features to expose them.

Please let me know if you prefer to handle this in a different way.

Thanks,
Tal